### PR TITLE
Train

### DIFF
--- a/yolo-gan-occlusion_handling.py
+++ b/yolo-gan-occlusion_handling.py
@@ -1,0 +1,6 @@
+from ultralytics import YOLO
+
+model_best = YOLO(r"D:\Dataset_parts\gan_yolo11n_seg1.pt")
+
+# Perform inference on the test dataset
+test_results = model_best.predict(source=r"D:\Dataset_parts\test_data-20250106T080124Z-001\test_data\seq_3\left_frames", save=True, save_dir = r"D:\Dataset_parts\results")

--- a/yolo11n_seg.py
+++ b/yolo11n_seg.py
@@ -1,0 +1,19 @@
+from ultralytics import YOLO
+import os
+os.environ['CUDA_LAUNCH_BLOCKING'] = '1'
+
+def train_model():
+    
+# Load a pretrained YOLO11 model
+# Load a pretrained YOLOv8-segmentation model
+    model = YOLO("yolo11n-seg.yaml")  # Use a built-in segmentation model
+    model.train(data="D:\Dataset_parts\config.yaml", epochs=200, imgsz=640, batch=16)    
+
+# Evaluate the model's performance on a validation set
+    model.val(data="D:\Dataset_parts\config.yaml")
+
+# Save the trained model
+    model.save("D:\Dataset_parts\2018_1.pt")
+ 
+if __name__ == "__main__":
+    train_model()


### PR DESCRIPTION
## Summary by Sourcery

Add standalone scripts to train a YOLO segmentation model and to perform inference on occlusion-handling test data

New Features:
- Add a training script (yolo11n_seg.py) to train and validate a YOLO segmentation model and save the checkpoint
- Add an inference script (yolo-gan-occlusion_handling.py) to run predictions on test data and save output images